### PR TITLE
feat: Add theming script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,5 @@ jobs:
   release:
     uses: cloudscape-design/actions/.github/workflows/release.yml@main
     secrets: inherit
+    with:
+      publish-packages: lib/components,lib/components-themeable

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## React components for Cloudscape Design System
+## Code view component for Cloudscape Design System
 
 This package contains the source code of the Code View component in the [Cloudscape Design System](https://cloudscape.design/).
 For more information about the code view component, see [the documentation](https://cloudscape.design/components/code-view/).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://cloudscape.design",
   "scripts": {
     "prebuild": "rm -rf lib dist .cache",
-    "build": "npm-run-all build:pkg --parallel build:src:* --parallel build:pages:*",
+    "build": "npm-run-all build:pkg --parallel build:src:* --parallel build:pages:* build:themeable",
     "lint": "eslint --ignore-path .gitignore --ext ts,tsx,js . && stylelint --ignore-path .gitignore '{src,pages}/**/*.{css,scss}'",
     "prepare": "husky install",
     "test:unit": "vitest run --config vite.unit.config.mjs",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:src:copy": "cp README.md lib/components/",
     "build:src:docs": "node scripts/docs.js",
     "build:src:environment": "node scripts/environment",
+    "build:themeable": "node scripts/themeable-source",
     "build:pages:vite": "vite build",
     "build:pages:tsc": "tsc -p pages/tsconfig.json"
   },

--- a/scripts/package-json.js
+++ b/scripts/package-json.js
@@ -6,11 +6,21 @@ import { writeJSON } from "./utils.js";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));
 
 mainPackage();
+themablePackage();
 
 function mainPackage() {
   writeJSON("lib/components/package.json", {
     ...pkg,
     // prevent postinstall scripts we use in our build from being published
     scripts: undefined,
+  });
+}
+
+function themablePackage() {
+  writeJSON("lib/components-themeable/package.json", {
+    name: "@cloudscape-design/code-view-themeable",
+    version: pkg.version,
+    repository: pkg.repository,
+    homepage: pkg.homepage,
   });
 }

--- a/scripts/themeable-source.js
+++ b/scripts/themeable-source.js
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { globbySync } from "globby";
+const cwd = process.cwd();
+
+const targetDir = path.join(cwd, "./lib/components-themeable/internal");
+console.log(targetDir);
+const stylesSourceDir = path.join(cwd, "./src/");
+const stylesTargetDir = path.join(targetDir, "/scss");
+
+const componentsSourceDir = path.join(cwd, "./lib/components");
+const componentsTargetDir = path.join(targetDir, "/template");
+
+function copyStyles() {
+  for (const file of globbySync("**/*.scss", { cwd: stylesSourceDir })) {
+    const content = fs.readFileSync(path.join(stylesSourceDir, file), "utf-8");
+    fs.mkdirSync(path.join(stylesTargetDir, path.dirname(file)), { recursive: true });
+    fs.writeFileSync(
+      path.join(stylesTargetDir, file),
+      content.replace(
+        /@use "(\.\.\/)+node_modules\/@cloudscape-design\/design-tokens\/index.scss"/,
+        '@use "awsui:tokens"'
+      ),
+      "utf-8"
+    );
+  }
+}
+
+function copyTemplate() {
+  fs.mkdirSync(componentsTargetDir, { recursive: true });
+  fs.cpSync(componentsSourceDir, componentsTargetDir, { recursive: true });
+}
+
+copyTemplate();
+copyStyles();

--- a/scripts/themeable-source.js
+++ b/scripts/themeable-source.js
@@ -7,7 +7,6 @@ import { globbySync } from "globby";
 const cwd = process.cwd();
 
 const targetDir = path.join(cwd, "./lib/components-themeable/internal");
-console.log(targetDir);
 const stylesSourceDir = path.join(cwd, "./src/");
 const stylesTargetDir = path.join(targetDir, "/scss");
 


### PR DESCRIPTION
### Description

Adding a script to generate a themeable package.


### How has this been tested?

Manually, running the internal theming package.
<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
