### PR TITLE
fix: add explict key to Fragment in createHighlight to prevent React unique key warnings

### DIFF
--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, getByText, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 import CodeView from "../../../lib/components/code-view";
 import styles from "../../../lib/components/code-view/styles.css.js";
 import createWrapper from "../../../lib/components/test-utils/dom";
+import typescriptHighlightRules from "../highlight/typescript";
 
 describe("CodeView", () => {
   afterEach(() => {
@@ -57,5 +58,17 @@ describe("CodeView", () => {
     );
     const wrapper = createWrapper().findCodeView()!;
     expect(wrapper!.findContent().getElement().innerHTML).toContain('class="tokenized"');
+  });
+
+  test("correctly tokenizes content if highlight is set to language rules", () => {
+    render(<CodeView content={'const hello: string = "world";'} highlight={typescriptHighlightRules}></CodeView>);
+    const wrapper = createWrapper().findCodeView()!;
+    const element = wrapper!.findContent().getElement();
+
+    // Check that the content is tokenized following typescript rules.
+    expect(getByText(element, "const")).toHaveClass("ace_type");
+    expect(getByText(element, "hello")).toHaveClass("ace_identifier");
+    expect(getByText(element, "string")).toHaveClass("ace_type");
+    expect(getByText(element, '"world"')).toHaveClass("ace_string");
   });
 });

--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -3,9 +3,9 @@
 import { cleanup, getByText, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 import CodeView from "../../../lib/components/code-view";
+import typescriptHighlightRules from "../../../lib/components/code-view/highlight/typescript";
 import styles from "../../../lib/components/code-view/styles.css.js";
 import createWrapper from "../../../lib/components/test-utils/dom";
-import typescriptHighlightRules from "../highlight/typescript";
 
 describe("CodeView", () => {
   afterEach(() => {

--- a/src/code-view/highlight/index.tsx
+++ b/src/code-view/highlight/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Ace } from "ace-code";
 import { tokenize } from "ace-code/src/ext/simple_tokenizer";
+import { Fragment } from "react";
 import "ace-code/styles/theme/cloud_editor.css";
 import "ace-code/styles/theme/cloud_editor_dark.css";
 
@@ -10,8 +11,8 @@ export function createHighlight(rules: Ace.HighlightRules) {
     const tokens = tokenize(code, rules);
     return (
       <span>
-        {tokens.map((lineTokens) => (
-          <>
+        {tokens.map((lineTokens, lineIndex) => (
+          <Fragment key={lineIndex}>
             {lineTokens.map((token, tokenIndex) => {
               return token.className ? (
                 <span className={token?.className} key={tokenIndex}>
@@ -22,7 +23,7 @@ export function createHighlight(rules: Ace.HighlightRules) {
               );
             })}
             {"\n"}
-          </>
+          </Fragment>
         ))}
       </span>
     );


### PR DESCRIPTION
### Description

Adds an explicit `key` to the `React.Fragment`s used in `createHighlight` to prevent React throwing warnings for an unique key missing from child nodes in a list.

Verified that the warning is no longer shown when running `npm run start` and added an unit test which threw the warning before this change and verified it doesn't throw it anymore after this change.

Related links, issue #, if available: #17
### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
