### PR TITLE
fix: Remove broken JSX highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "./highlight/java": "./code-view/highlight/java.js",
     "./highlight/javascript": "./code-view/highlight/javascript.js",
     "./highlight/json": "./code-view/highlight/json.js",
-    "./highlight/jsx": "./code-view/highlight/jsx.js",
     "./highlight/kotlin": "./code-view/highlight/kotlin.js",
     "./highlight/markdown": "./code-view/highlight/markdown.js",
     "./highlight/php": "./code-view/highlight/php.js",

--- a/src/code-view/highlight/jsx.ts
+++ b/src/code-view/highlight/jsx.ts
@@ -1,6 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-import { JsxHighlightRules } from "ace-code/src/mode/jsx_highlight_rules";
-import { createHighlight } from ".";
-
-export default createHighlight(new JsxHighlightRules());


### PR DESCRIPTION
### Description

This PR removes JSX highlighting, which was removed from Ace in [this PR](https://github.com/ajaxorg/ace/pull/5451). As stated in that PR, that highlighter never did what developers nowadays would expect, since it highlights for a language that has nothing to do with React's JSX, so there is nothing lost by removing this.

Related lissue: `D122503501`

### How has this been tested?

Locally build and manually verified existing pages.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
