### PR TITLE
fix: Remove broken higlight rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "./highlight/ruby": "./code-view/highlight/ruby.js",
     "./highlight/rust": "./code-view/highlight/rust.js",
     "./highlight/sh": "./code-view/highlight/sh.js",
-    "./highlight/swift": "./code-view/highlight/swift.js",
     "./highlight/typescript": "./code-view/highlight/typescript.js",
     "./highlight/xml": "./code-view/highlight/xml.js",
     "./highlight/yaml": "./code-view/highlight/yaml.js",

--- a/src/code-view/__tests__/highlight.test.ts
+++ b/src/code-view/__tests__/highlight.test.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import { describe, expect, test } from "vitest";
+
+const dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const rulesDir = path.resolve(dirname, "../highlight");
+const rules = fs.readdirSync(rulesDir).filter((file) => file !== "index.tsx");
+
+describe("highlight rules can be loaded", () => {
+  test.each(rules)("%s", async (rule) => {
+    // eslint-disable-next-line no-unsanitized/method
+    const { default: highlight } = await import(path.join(rulesDir, rule));
+    expect(highlight("")).toBeDefined();
+  });
+});

--- a/src/code-view/highlight/swift.ts
+++ b/src/code-view/highlight/swift.ts
@@ -1,6 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-import { SwiftHighlightRules } from "ace-code/src/mode/swift_highlight_rules";
-import { createHighlight } from ".";
-
-export default createHighlight(new SwiftHighlightRules());


### PR DESCRIPTION
### Description

This import is broken on ace-code end: https://github.com/ajaxorg/ace/issues/5511

Let's remove this for now


Related links, issue #, if available: n/a

### How has this been tested?

PR build. 

Added extra tests to ensure all rules are working

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
