### PR TITLE
chore: Force the component direction to LTR.

### DIFF
--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -40,6 +40,7 @@ export function InternalCodeView({
       {...baseProps}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
+      dir="ltr"
       ref={__internalRootRef}
     >
       <div className={clsx(lineNumbers && styles["root-with-numbers"], actions && styles["root-with-actions"])}>


### PR DESCRIPTION
This is a small change that forces the component direction to LTR. This is because the supported languages in the code view should read left-to-right regardless of the direction of the document or any other DOM ancestors.