### PR TITLE
chore: Raise size-limit value

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   "size-limit": [
     {
       "path": "lib/components/index.js",
-      "limit": "6.2kb"
+      "limit": "6.3kb"
     },
     {
       "path": "lib/components/code-view/highlight/javascript.js",


### PR DESCRIPTION
### Description

This change https://github.com/cloudscape-design/component-toolkit/pull/79 in `useVisualRefresh` hook caused a size increase.

I did not find any opportunities to optimize, so let's accept this increase.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
