### PR TITLE
chore: Import sort plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
       "jsx": true
     }
   },
-  "plugins": ["unicorn", "react-hooks", "no-unsanitized", "header", "import"],
+  "plugins": ["unicorn", "react-hooks", "no-unsanitized", "header", "import", "simple-import-sort"],
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
@@ -69,14 +69,13 @@
         ]
       }
     ],
-    "sort-imports": ["error", { "ignoreDeclarationSort": true }],
-    "import/order": ["error", { "alphabetize": { "order": "asc" } }],
     "import/no-useless-path-segments": [
       "warn",
       {
         "noUselessIndex": true
       }
-    ]
+    ],
+    "simple-import-sort/imports": "warn"
   },
   "settings": {
     "react": {
@@ -97,6 +96,30 @@
       },
       "env": {
         "jest": true
+      }
+    },
+    {
+      "files": ["src/**", "pages/**", "test/**", "scripts/**"],
+      "rules": {
+        "simple-import-sort/imports": [
+          "warn",
+          {
+            "groups": [
+              // External packages come first.
+              ["^react", "^\\w", "^@testing", "^@vite"],
+              // Cloudscape packages.
+              ["^@cloudscape"],
+              // Things that start with a letter (or digit or underscore), or `~` followed by a letter.
+              ["^~?\\w"],
+              // Anything not matched in another group.
+              ["^"],
+              // Styles come last.
+              [
+                "^.+\\.?(css)$","^.+\\.?(css.js)$", "^.+\\.?(scss)$", "^.+\\.?(selectors.js)$"
+              ]
+            ]
+          }
+        ]
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -75,7 +75,7 @@
         "noUselessIndex": true
       }
     ],
-    "simple-import-sort/imports": "warn"
+    "simple-import-sort/imports": "error"
   },
   "settings": {
     "react": {
@@ -102,7 +102,7 @@
       "files": ["src/**", "pages/**", "test/**", "scripts/**"],
       "rules": {
         "simple-import-sort/imports": [
-          "warn",
+          "error",
           {
             "groups": [
               // External packages come first.

--- a/.eslintrc
+++ b/.eslintrc
@@ -106,11 +106,11 @@
           {
             "groups": [
               // External packages come first.
-              ["^react", "^\\w", "^(?!@cloudscape)@?\\w"],
+              ["^react", "^(?!@cloudscape)@?\\w"],
               // Cloudscape packages.
               ["^@cloudscape"],
               // Things that start with a letter (or digit or underscore), or `~` followed by a letter.
-              ["^~?\\w"],
+              ["^~\\w"],
               // Anything not matched in another group.
               ["^"],
               // Styles come last.

--- a/.eslintrc
+++ b/.eslintrc
@@ -106,7 +106,7 @@
           {
             "groups": [
               // External packages come first.
-              ["^react", "^\\w", "^@testing", "^@vite"],
+              ["^react", "^\\w", "^(?!@cloudscape)@?\\w"],
               // Cloudscape packages.
               ["^@cloudscape"],
               // Things that start with a letter (or digit or underscore), or `~` followed by a letter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.11",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unicorn": "^45.0.2",
         "execa": "^6.1.0",
         "globby": "^13.1.3",
@@ -1748,6 +1749,21 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -2166,6 +2182,27 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -5048,6 +5085,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -7054,6 +7102,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "45.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz",
@@ -7618,6 +7675,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -9539,6 +9616,19 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -12583,6 +12673,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
@@ -14519,6 +14618,25 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/webdriver": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unicorn": "^45.0.2",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "execa": "^6.1.0",
     "globby": "^13.1.3",
     "husky": "^8.0.3",

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { HashRouter, Link, Route, Routes, useLocation } from "react-router-dom";
+
 import { pages } from "../pages";
 import Page from "./page";
 

--- a/pages/app/page.tsx
+++ b/pages/app/page.tsx
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SpaceBetween, Toggle } from "@cloudscape-design/components";
-import { Density, Mode, applyDensity, applyMode } from "@cloudscape-design/global-styles";
 import { Suspense } from "react";
 import { useEffect, useState } from "react";
+
+import { SpaceBetween, Toggle } from "@cloudscape-design/components";
+import { applyDensity, applyMode, Density, Mode } from "@cloudscape-design/global-styles";
+
 import { pagesMap } from "../pages";
 import PageLayout from "./page-layout";
 

--- a/pages/code-view/with-actions-button.page.tsx
+++ b/pages/code-view/with-actions-button.page.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button, SpaceBetween } from "@cloudscape-design/components";
+
 import { CodeView } from "../../lib/components";
 import { ScreenshotArea } from "../screenshot-area";
 export default function CodeViewPage() {

--- a/pages/code-view/with-all-features.page.tsx
+++ b/pages/code-view/with-all-features.page.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from "@cloudscape-design/components";
+
 import { CodeView } from "../../lib/components";
 import javascriptHighlight from "../../lib/components/code-view/highlight/javascript";
 import { ScreenshotArea } from "../screenshot-area";

--- a/pages/code-view/with-line-numbers.page.tsx
+++ b/pages/code-view/with-line-numbers.page.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SpaceBetween } from "@cloudscape-design/components";
-import { CodeView } from "../../lib/components";
 
+import { CodeView } from "../../lib/components";
 import { ScreenshotArea } from "../screenshot-area";
 export default function CodeViewPage() {
   return (

--- a/pages/code-view/with-syntax-highlighting.page.tsx
+++ b/pages/code-view/with-syntax-highlighting.page.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SpaceBetween } from "@cloudscape-design/components";
+
 import { CodeView } from "../../lib/components";
-import cssHighlight from "../../lib/components/code-view/highlight/css";
 import htmlHighlight from "../../lib/components/code-view/highlight/html";
 import javaHighlight from "../../lib/components/code-view/highlight/java";
 import javascriptHighlight from "../../lib/components/code-view/highlight/javascript";
@@ -15,8 +15,9 @@ import shHighlight from "../../lib/components/code-view/highlight/sh";
 import typescriptHighlight from "../../lib/components/code-view/highlight/typescript";
 import xmlHighlight from "../../lib/components/code-view/highlight/xml";
 import yamlHighlight from "../../lib/components/code-view/highlight/yaml";
-
 import { ScreenshotArea } from "../screenshot-area";
+
+import cssHighlight from "../../lib/components/code-view/highlight/css";
 export default function CodeViewPage() {
   return (
     <ScreenshotArea>

--- a/pages/main.tsx
+++ b/pages/main.tsx
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
-import "@cloudscape-design/global-styles/index.css";
 
 import App from "./app";
+
+import "@cloudscape-design/global-styles/index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -3,6 +3,7 @@
 import path from "node:path";
 
 import { documentComponents, documentTestUtils } from "@cloudscape-design/documenter";
+
 import { dashCase, listPublicDirs, writeSourceFile } from "./utils.js";
 
 const publicDirs = listPublicDirs("src");

--- a/scripts/package-json.js
+++ b/scripts/package-json.js
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import fs from "node:fs";
+
 import { writeJSON } from "./utils.js";
 
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));

--- a/scripts/test-utils.js
+++ b/scripts/test-utils.js
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import fs from "node:fs";
-import path from "node:path";
-import { default as convertToSelectorUtil } from "@cloudscape-design/test-utils-converter";
 import { execaSync } from "execa";
 import { globbySync } from "globby";
+import fs from "node:fs";
+import path from "node:path";
+
+import { default as convertToSelectorUtil } from "@cloudscape-design/test-utils-converter";
+
 import { pascalCase, writeSourceFile } from "./utils.js";
 
 const components = globbySync(["src/test-utils/dom/**/index.ts", "!src/test-utils/dom/index.ts"]).map((fileName) =>

--- a/scripts/themeable-source.js
+++ b/scripts/themeable-source.js
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { globbySync } from "globby";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { globbySync } from "globby";
 const cwd = process.cwd();
 
 const targetDir = path.join(cwd, "./lib/components-themeable/internal");

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import lodash from "lodash";
 import fs from "node:fs";
 import path from "node:path";
-import lodash from "lodash";
 
 export function pascalCase(text) {
   return capitalize(lodash.camelCase(text));

--- a/src/__tests__/base-props-support.test.tsx
+++ b/src/__tests__/base-props-support.test.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ReactElement } from "react";
-import { describe, expect, test } from "vitest";
 import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
 
 import * as components from "../../lib/components";
 import { defaultProps } from "./default-props";

--- a/src/__tests__/base-props-support.test.tsx
+++ b/src/__tests__/base-props-support.test.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { render } from "@testing-library/react";
 import { ReactElement } from "react";
 import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+
 import * as components from "../../lib/components";
 import { defaultProps } from "./default-props";
 

--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
+
 // @ts-expect-error no types here
 import apiDocs from "../../lib/components/internal/api-docs/components";
 

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,7 +3,7 @@
 
 // type-only import, because in runtime it tries to access Jest globals, which do not exist
 /// <reference types="@testing-library/jest-dom" />
-import { expect } from "vitest";
 import matchers from "@testing-library/jest-dom/matchers";
+import { expect } from "vitest";
 
 expect.extend(matchers);

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,7 +3,7 @@
 
 // type-only import, because in runtime it tries to access Jest globals, which do not exist
 /// <reference types="@testing-library/jest-dom" />
-import matchers from "@testing-library/jest-dom/matchers";
 import { expect } from "vitest";
+import matchers from "@testing-library/jest-dom/matchers";
 
 expect.extend(matchers);

--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -1,11 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { cleanup, getByText, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, getByText, render } from "@testing-library/react";
+
 import CodeView from "../../../lib/components/code-view";
 import typescriptHighlightRules from "../../../lib/components/code-view/highlight/typescript";
-import styles from "../../../lib/components/code-view/styles.css.js";
 import createWrapper from "../../../lib/components/test-utils/dom";
+
+import styles from "../../../lib/components/code-view/styles.css.js";
 
 describe("CodeView", () => {
   afterEach(() => {

--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { afterEach, describe, expect, test } from "vitest";
 import { cleanup, getByText, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
 
 import CodeView from "../../../lib/components/code-view";
 import typescriptHighlightRules from "../../../lib/components/code-view/highlight/typescript";

--- a/src/code-view/highlight/cpp.ts
+++ b/src/code-view/highlight/cpp.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { c_cppHighlightRules } from "ace-code/src/mode/c_cpp_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new c_cppHighlightRules());

--- a/src/code-view/highlight/csharp.ts
+++ b/src/code-view/highlight/csharp.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { CSharpHighlightRules } from "ace-code/src/mode/csharp_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new CSharpHighlightRules());

--- a/src/code-view/highlight/css.ts
+++ b/src/code-view/highlight/css.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { CssHighlightRules } from "ace-code/src/mode/css_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new CssHighlightRules());

--- a/src/code-view/highlight/go.ts
+++ b/src/code-view/highlight/go.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { GolangHighlightRules } from "ace-code/src/mode/golang_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new GolangHighlightRules());

--- a/src/code-view/highlight/html.ts
+++ b/src/code-view/highlight/html.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { HtmlHighlightRules } from "ace-code/src/mode/html_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new HtmlHighlightRules());

--- a/src/code-view/highlight/index.tsx
+++ b/src/code-view/highlight/index.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Fragment } from "react";
 import type { Ace } from "ace-code";
 import { tokenize } from "ace-code/src/ext/simple_tokenizer";
-import { Fragment } from "react";
+
 import "ace-code/styles/theme/cloud_editor.css";
 import "ace-code/styles/theme/cloud_editor_dark.css";
 

--- a/src/code-view/highlight/java.ts
+++ b/src/code-view/highlight/java.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { JavaHighlightRules } from "ace-code/src/mode/java_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new JavaHighlightRules());

--- a/src/code-view/highlight/javascript.ts
+++ b/src/code-view/highlight/javascript.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { JavaScriptHighlightRules } from "ace-code/src/mode/javascript_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new JavaScriptHighlightRules());

--- a/src/code-view/highlight/json.ts
+++ b/src/code-view/highlight/json.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { JsonHighlightRules } from "ace-code/src/mode/json_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new JsonHighlightRules());

--- a/src/code-view/highlight/kotlin.ts
+++ b/src/code-view/highlight/kotlin.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { KotlinHighlightRules } from "ace-code/src/mode/kotlin_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new KotlinHighlightRules());

--- a/src/code-view/highlight/markdown.ts
+++ b/src/code-view/highlight/markdown.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { MarkdownHighlightRules } from "ace-code/src/mode/markdown_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new MarkdownHighlightRules());

--- a/src/code-view/highlight/php.ts
+++ b/src/code-view/highlight/php.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { PhpHighlightRules } from "ace-code/src/mode/php_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new PhpHighlightRules());

--- a/src/code-view/highlight/python.ts
+++ b/src/code-view/highlight/python.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { PythonHighlightRules } from "ace-code/src/mode/python_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new PythonHighlightRules());

--- a/src/code-view/highlight/ruby.ts
+++ b/src/code-view/highlight/ruby.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { RubyHighlightRules } from "ace-code/src/mode/ruby_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new RubyHighlightRules());

--- a/src/code-view/highlight/rust.ts
+++ b/src/code-view/highlight/rust.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { RustHighlightRules } from "ace-code/src/mode/rust_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new RustHighlightRules());

--- a/src/code-view/highlight/sh.ts
+++ b/src/code-view/highlight/sh.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ShHighlightRules } from "ace-code/src/mode/sh_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new ShHighlightRules());

--- a/src/code-view/highlight/typescript.ts
+++ b/src/code-view/highlight/typescript.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { TypeScriptHighlightRules } from "ace-code/src/mode/typescript_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new TypeScriptHighlightRules());

--- a/src/code-view/highlight/xml.ts
+++ b/src/code-view/highlight/xml.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { XmlHighlightRules } from "ace-code/src/mode/xml_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new XmlHighlightRules());

--- a/src/code-view/highlight/yaml.ts
+++ b/src/code-view/highlight/yaml.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { YamlHighlightRules } from "ace-code/src/mode/yaml_highlight_rules";
+
 import { createHighlight } from ".";
 
 export default createHighlight(new YamlHighlightRules());

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -1,11 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useRef } from "react";
+import clsx from "clsx";
+
 import { useCurrentMode } from "@cloudscape-design/component-toolkit/internal";
 import Box from "@cloudscape-design/components/box";
-import clsx from "clsx";
-import { useRef } from "react";
-import { InternalBaseComponentProps, getBaseProps } from "../internal/base-component/use-base-component";
+
+import { getBaseProps, InternalBaseComponentProps } from "../internal/base-component/use-base-component";
 import { CodeViewProps } from "./interfaces";
+
 import styles from "./styles.css.js";
 
 const ACE_CLASSES = { light: "ace-cloud_editor", dark: "ace-cloud_editor_dark" };

--- a/src/internal/base-component/use-base-component.ts
+++ b/src/internal/base-component/use-base-component.ts
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { MutableRefObject } from "react";
+
 import {
   ComponentConfiguration,
   initAwsUiVersions,
   useComponentMetadata,
 } from "@cloudscape-design/component-toolkit/internal";
-import { MutableRefObject } from "react";
+
 import { PACKAGE_SOURCE, PACKAGE_VERSION } from "../environment";
 import { useTelemetry } from "./use-telemetry";
 

--- a/src/internal/base-component/use-telemetry.ts
+++ b/src/internal/base-component/use-telemetry.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ComponentConfiguration, useComponentMetrics } from "@cloudscape-design/component-toolkit/internal";
+
 import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from "../environment";
 import { useVisualRefresh } from "./use-visual-refresh";
 

--- a/src/internal/base-component/use-visual-refresh.ts
+++ b/src/internal/base-component/use-visual-refresh.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRuntimeVisualRefresh } from "@cloudscape-design/component-toolkit/internal";
+
 import { ALWAYS_VISUAL_REFRESH } from "../environment";
 
 export const useVisualRefresh = ALWAYS_VISUAL_REFRESH ? () => true : useRuntimeVisualRefresh;

--- a/src/test-utils/dom/code-view/index.ts
+++ b/src/test-utils/dom/code-view/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from "@cloudscape-design/test-utils-core/dom";
+
 import styles from "../../../code-view/styles.selectors.js";
 
 export default class CodeViewWrapper extends ComponentWrapper {

--- a/test/visual-test-setup.ts
+++ b/test/visual-test-setup.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { join } from "path";
 import { configureToMatchImageSnapshot } from "jest-image-snapshot";
+import { join } from "path";
 import { expect } from "vitest";
 
 const snapshotDir = join(__dirname, "./..", process.env.VISUAL_REGRESSION_SNAPSHOT_DIRECTORY ?? "__image_snapshots__");

--- a/test/visual/index.test.ts
+++ b/test/visual/index.test.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import path from "path";
-import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import { expect, test } from "vitest";
+
+import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
+
 import { setupTest } from "../utils";
 
 const pagesMap = import.meta.glob("../../pages/**/*.page.tsx", { as: "raw" });


### PR DESCRIPTION
### Description

Introduced a new plugin to group and alphabetically sort imports in the following order:

external packages
cloudscape packages
internal imports
styles

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
