### PR TITLE
fix: Fix line numbers misalignment with single-line content when actions are provided

### DIFF
--- a/pages/code-view/with-line-numbers.page.tsx
+++ b/pages/code-view/with-line-numbers.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { SpaceBetween } from "@cloudscape-design/components";
+import { Button, SpaceBetween } from "@cloudscape-design/components";
 
 import { CodeView } from "../../lib/components";
 import { ScreenshotArea } from "../screenshot-area";
@@ -12,6 +12,11 @@ export default function CodeViewPage() {
       <SpaceBetween direction="vertical" size="l">
         <CodeView lineNumbers={true} content={`# Hello World`} />
         <CodeView lineNumbers={true} content={`# Hello World\n\nThis is Cloudscape.`} />
+        <CodeView
+          lineNumbers={true}
+          content={`# Hello World`}
+          actions={<Button ariaLabel="Copy code" iconName="copy"></Button>}
+        />
       </SpaceBetween>
     </ScreenshotArea>
   );

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -49,7 +49,10 @@ export function InternalCodeView({
       <div className={clsx(lineNumbers && styles["root-with-numbers"], actions && styles["root-with-actions"])}>
         <Box color="text-status-inactive" fontSize="body-m">
           {lineNumbers && (
-            <div className={styles["line-numbers"]} aria-hidden={true}>
+            <div
+              className={clsx(styles["line-numbers"], actions && styles["line-numbers-with-actions"])}
+              aria-hidden={true}
+            >
               {getLineNumbers(content).map((number) => (
                 <span key={number}>{number}</span>
               ))}

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -49,6 +49,9 @@ $color-background-code-view-dark: #282c34;
   :global(.awsui-polaris-dark-mode) & {
     background-color: $color-background-code-view-dark;
   }
+  &-with-actions {
+    min-block-size: cs.$space-scaled-xxl;
+  }
   border-start-start-radius: cs.$border-radius-tiles;
   border-end-start-radius: cs.$border-radius-tiles;
   background-color: $color-background-code-view-light;


### PR DESCRIPTION
### Description

We add a min height to the content when actions aren't provided, but we don't add that min height to the line numbers container, so it doesn't match. This happens with both themes.

Related links, issue #, if available: AWSUI-58645

### How has this been tested?

Added a screenshot test for line numbers and actions.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
