### PR TITLE
feat: Adds findAll finder to test utils

### DIFF
--- a/scripts/pluralize.js
+++ b/scripts/pluralize.js
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+const pluralizationMap = {
+  CodeView: "CodeViews",
+};
+
+function pluralizeComponentName(componentName) {
+  if (!(componentName in pluralizationMap)) {
+    throw new Error(`Could not find the plural case for ${componentName}.`);
+  }
+
+  return pluralizationMap[componentName];
+}
+
+export { pluralizeComponentName };

--- a/scripts/test-utils.js
+++ b/scripts/test-utils.js
@@ -7,11 +7,119 @@ import path from "node:path";
 
 import { default as convertToSelectorUtil } from "@cloudscape-design/test-utils-converter";
 
+import { pluralizeComponentName } from "./pluralize.js";
 import { pascalCase, writeSourceFile } from "./utils.js";
 
 const components = globbySync(["src/test-utils/dom/**/index.ts", "!src/test-utils/dom/index.ts"]).map((fileName) =>
   fileName.replace("src/test-utils/dom/", "").replace("/index.ts", ""),
 );
+
+function toWrapper(componentClass) {
+  return `${componentClass}Wrapper`;
+}
+
+const configs = {
+  common: {
+    buildFinder: ({ componentName, componentNamePlural }) => `
+      ElementWrapper.prototype.find${componentName} = function(selector) {
+        const rootSelector = \`.$\{${toWrapper(componentName)}.rootSelector}\`;
+        // casting to 'any' is needed to avoid this issue with generics
+        // https://github.com/microsoft/TypeScript/issues/29132
+        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ${toWrapper(componentName)});
+      };
+
+      ElementWrapper.prototype.findAll${componentNamePlural} = function(selector) {
+        return this.findAllComponents(${toWrapper(componentName)}, selector);
+      };`,
+  },
+  dom: {
+    defaultExport: `export default function wrapper(root: Element = document.body) { if (document && document.body && !document.body.contains(root)) { console.warn('[AwsUi] [test-utils] provided element is not part of the document body, interactions may work incorrectly')}; return new ElementWrapper(root); }`,
+    buildFinderInterface: ({ componentName, componentNamePlural }) => `
+       /**
+        * Returns the wrapper of the first ${componentName} that matches the specified CSS selector.
+        * If no CSS selector is specified, returns the wrapper of the first ${componentName}.
+        * If no matching ${componentName} is found, returns \`null\`.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {${toWrapper(componentName)} | null}
+        */
+       find${componentName}(selector?: string): ${toWrapper(componentName)} | null;
+
+       /**
+        * Returns an array of ${componentName} wrapper that matches the specified CSS selector.
+        * If no CSS selector is specified, returns all of the ${componentNamePlural} inside the current wrapper.
+        * If no matching ${componentName} is found, returns an empty array.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {Array<${toWrapper(componentName)}>}
+        */
+       findAll${componentNamePlural}(selector?: string): Array<${toWrapper(componentName)}>;`,
+  },
+  selectors: {
+    defaultExport: `export default function wrapper(root: string = 'body') { return new ElementWrapper(root); }`,
+    buildFinderInterface: ({ componentName, componentNamePlural }) => `
+       /**
+        * Returns a wrapper that matches the ${componentNamePlural} with the specified CSS selector.
+        * If no CSS selector is specified, returns a wrapper that matches ${componentNamePlural}.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {${toWrapper(componentName)}}
+        */
+       find${componentName}(selector?: string): ${toWrapper(componentName)};
+
+       /**
+        * Returns a multi-element wrapper that matches ${componentNamePlural} with the specified CSS selector.
+        * If no CSS selector is specified, returns a multi-element wrapper that matches ${componentNamePlural}.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {MultiElementWrapper<${toWrapper(componentName)}>}
+        */
+       findAll${componentNamePlural}(selector?: string): MultiElementWrapper<${toWrapper(componentName)}>;`,
+  },
+};
+
+function generateTestUtilMetaData() {
+  const testUtilsSrcDir = path.resolve("src/test-utils");
+  const metaData = components.reduce((allMetaData, componentFolderName) => {
+    const absPathComponentFolder = path.resolve(testUtilsSrcDir, componentFolderName);
+    const relPathTestUtilFile = `./${path.relative(testUtilsSrcDir, absPathComponentFolder)}`;
+
+    const componentNameKebab = componentFolderName;
+    const componentName = pascalCase(componentNameKebab);
+    const componentNamePlural = pluralizeComponentName(componentName);
+
+    const componentMetaData = {
+      componentName,
+      componentNamePlural,
+      relPathTestUtilFile,
+    };
+
+    return allMetaData.concat(componentMetaData);
+  }, []);
+
+  return metaData;
+}
+
+function generateFindersInterfaces({ testUtilMetaData, testUtilType, configs }) {
+  const { buildFinderInterface } = configs[testUtilType];
+  const findersInterfaces = testUtilMetaData.map(buildFinderInterface);
+
+  // we need to redeclare the interface in its original definition, extending a re-export will not work
+  // https://github.com/microsoft/TypeScript/issues/12607
+  const interfaces = `declare module '@cloudscape-design/test-utils-core/dist/${testUtilType}' {
+      interface ElementWrapper {
+        ${findersInterfaces.join("\n")}
+      }
+  }`;
+
+  return interfaces;
+}
+
+function generateFindersImplementations({ testUtilMetaData, configs }) {
+  const { buildFinder } = configs.common;
+  const findersImplementations = testUtilMetaData.map(buildFinder);
+  return findersImplementations.join("\n");
+}
 
 generateSelectorUtils();
 generateDomIndexFile();
@@ -31,8 +139,7 @@ function generateSelectorUtils() {
 function generateDomIndexFile() {
   const content = generateIndexFileContent({
     testUtilType: "dom",
-    buildFinderInterface: (componentName) =>
-      `find${pascalCase(componentName)}(selector?: string): ${pascalCase(componentName)}Wrapper | null;`,
+    testUtilMetaData: generateTestUtilMetaData(),
   });
   writeSourceFile("./src/test-utils/dom/index.ts", content);
 }
@@ -40,44 +147,34 @@ function generateDomIndexFile() {
 function generateSelectorsIndexFile() {
   const content = generateIndexFileContent({
     testUtilType: "selectors",
-    buildFinderInterface: (componentName) =>
-      `find${pascalCase(componentName)}(selector?: string): ${pascalCase(componentName)}Wrapper;`,
+    testUtilMetaData: generateTestUtilMetaData(),
   });
   writeSourceFile("./src/test-utils/selectors/index.ts", content);
 }
 
-function generateIndexFileContent({ testUtilType, buildFinderInterface }) {
+function generateIndexFileContent({ testUtilType, testUtilMetaData }) {
+  const config = configs[testUtilType];
+  if (config === undefined) {
+    throw new Error("Unknown test util type");
+  }
+
   return [
     // language=TypeScript
     `import { ElementWrapper } from '@cloudscape-design/test-utils-core/${testUtilType}';`,
+    `import '@cloudscape-design/components/test-utils/${testUtilType}';`,
     `import { appendSelector } from '@cloudscape-design/test-utils-core/utils';`,
     `export { ElementWrapper };`,
-    ...components.map((componentName) => {
-      const componentImport = `./${componentName}/index`;
+    ...testUtilMetaData.map((metaData) => {
+      const { componentName, relPathTestUtilFile } = metaData;
+
       return `
-        import ${pascalCase(componentName)}Wrapper from '${componentImport}';
-        export { ${pascalCase(componentName)}Wrapper };
+        import ${toWrapper(componentName)} from '${relPathTestUtilFile}';
+        export { ${componentName}Wrapper };
       `;
     }),
-    // we need to redeclare the interface in its original definition, extending a re-export will not work
-    // https://github.com/microsoft/TypeScript/issues/12607
-    `declare module '@cloudscape-design/test-utils-core/dist/${testUtilType}' {
-      interface ElementWrapper {
-        ${components.map((componentName) => buildFinderInterface(componentName)).join("\n")}
-      }
-    }`,
-    ...components.map((componentName) => {
-      // language=TypeScript
-      return `ElementWrapper.prototype.find${pascalCase(componentName)} = function(selector) {
-          const rootSelector = \`.$\{${pascalCase(componentName)}Wrapper.rootSelector}\`;
-          // casting to 'any' is needed to avoid this issue with generics
-          // https://github.com/microsoft/TypeScript/issues/29132
-          return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ${pascalCase(
-            componentName,
-          )}Wrapper);
-      };`;
-    }),
-    `export { createWrapper as default } from '@cloudscape-design/test-utils-core/${testUtilType}';`,
+    generateFindersInterfaces({ testUtilMetaData, testUtilType, configs }),
+    generateFindersImplementations({ testUtilMetaData, configs }),
+    config.defaultExport,
   ].join("\n");
 }
 

--- a/src/__tests__/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -1,0 +1,93 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Generate test utils ElementWrapper > 'dom' ElementWrapper matches the snapshot 1`] = `
+"import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import '@cloudscape-design/components/test-utils/dom';
+import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
+export { ElementWrapper };
+
+        import CodeViewWrapper from './code-view';
+        export { CodeViewWrapper };
+      
+declare module '@cloudscape-design/test-utils-core/dist/dom' {
+      interface ElementWrapper {
+        
+       /**
+        * Returns the wrapper of the first CodeView that matches the specified CSS selector.
+        * If no CSS selector is specified, returns the wrapper of the first CodeView.
+        * If no matching CodeView is found, returns \`null\`.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {CodeViewWrapper | null}
+        */
+       findCodeView(selector?: string): CodeViewWrapper | null;
+
+       /**
+        * Returns an array of CodeView wrapper that matches the specified CSS selector.
+        * If no CSS selector is specified, returns all of the CodeViews inside the current wrapper.
+        * If no matching CodeView is found, returns an empty array.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {Array<CodeViewWrapper>}
+        */
+       findAllCodeViews(selector?: string): Array<CodeViewWrapper>;
+      }
+  }
+
+      ElementWrapper.prototype.findCodeView = function(selector) {
+        const rootSelector = \`.\${CodeViewWrapper.rootSelector}\`;
+        // casting to 'any' is needed to avoid this issue with generics
+        // https://github.com/microsoft/TypeScript/issues/29132
+        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CodeViewWrapper);
+      };
+
+      ElementWrapper.prototype.findAllCodeViews = function(selector) {
+        return this.findAllComponents(CodeViewWrapper, selector);
+      };
+export default function wrapper(root: Element = document.body) { if (document && document.body && !document.body.contains(root)) { console.warn('[AwsUi] [test-utils] provided element is not part of the document body, interactions may work incorrectly')}; return new ElementWrapper(root); }"
+`;
+
+exports[`Generate test utils ElementWrapper > 'selectors' ElementWrapper matches the snapshot 1`] = `
+"import { ElementWrapper } from '@cloudscape-design/test-utils-core/selectors';
+import '@cloudscape-design/components/test-utils/selectors';
+import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
+export { ElementWrapper };
+
+        import CodeViewWrapper from './code-view';
+        export { CodeViewWrapper };
+      
+declare module '@cloudscape-design/test-utils-core/dist/selectors' {
+      interface ElementWrapper {
+        
+       /**
+        * Returns a wrapper that matches the CodeViews with the specified CSS selector.
+        * If no CSS selector is specified, returns a wrapper that matches CodeViews.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {CodeViewWrapper}
+        */
+       findCodeView(selector?: string): CodeViewWrapper;
+
+       /**
+        * Returns a multi-element wrapper that matches CodeViews with the specified CSS selector.
+        * If no CSS selector is specified, returns a multi-element wrapper that matches CodeViews.
+        *
+        * @param {string} [selector] CSS Selector
+        * @returns {MultiElementWrapper<CodeViewWrapper>}
+        */
+       findAllCodeViews(selector?: string): MultiElementWrapper<CodeViewWrapper>;
+      }
+  }
+
+      ElementWrapper.prototype.findCodeView = function(selector) {
+        const rootSelector = \`.\${CodeViewWrapper.rootSelector}\`;
+        // casting to 'any' is needed to avoid this issue with generics
+        // https://github.com/microsoft/TypeScript/issues/29132
+        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CodeViewWrapper);
+      };
+
+      ElementWrapper.prototype.findAllCodeViews = function(selector) {
+        return this.findAllComponents(CodeViewWrapper, selector);
+      };
+export default function wrapper(root: string = 'body') { return new ElementWrapper(root); }"
+`;

--- a/src/__tests__/test-utils-wrappers.test.tsx
+++ b/src/__tests__/test-utils-wrappers.test.tsx
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import fs from "fs";
+import path from "path";
+import { describe, expect, test } from "vitest";
+
+describe("Generate test utils ElementWrapper", () => {
+  const importPaths = [
+    {
+      type: "dom",
+      relativePath: "../test-utils/dom/index.ts",
+    },
+    {
+      type: "selectors",
+      relativePath: "../test-utils/selectors/index.ts",
+    },
+  ] as const;
+
+  test.each(importPaths)("$type ElementWrapper matches the snapshot", ({ relativePath }) => {
+    const testUtilsPath = path.join(__dirname, relativePath);
+    const domWrapper = fs.readFileSync(testUtilsPath, "utf8");
+    expect(domWrapper).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/test-utils.test.tsx
+++ b/src/__tests__/test-utils.test.tsx
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentType } from "react";
+import { render } from "@testing-library/react";
+import { paramCase, pascalCase } from "change-case";
+import { describe, expect, test } from "vitest";
+
+import * as components from "../../lib/components";
+import createWrapperDom, { ElementWrapper as DomElementWrapper } from "../../lib/components/test-utils/dom";
+import createWrapperSelectors from "../../lib/components/test-utils/selectors";
+import { defaultProps } from "./default-props";
+
+const RENDER_COMPONENTS_DEFAULT_PROPS: Record<string, unknown>[] = [
+  {
+    "data-testid": "first-item",
+    "data-name": "first item",
+  },
+  {
+    "data-testid": "second-item",
+    "data-name": "second item",
+  },
+];
+
+function renderComponents(componentName: string, props = RENDER_COMPONENTS_DEFAULT_PROPS) {
+  const Component = components[componentName as keyof typeof components] as ComponentType;
+  const componentDefaultProps = defaultProps[paramCase(componentName) as keyof typeof defaultProps];
+  return render(
+    <div>
+      {props.map(({ ...customProps }, index) => (
+        <Component key={index} {...componentDefaultProps} {...customProps} />
+      ))}
+    </div>,
+  );
+}
+
+function getComponentSelectors(componentName: string) {
+  const componentNamePascalCase = pascalCase(componentName);
+  const findAllRegex = new RegExp(`findAll${componentNamePascalCase}.*`);
+
+  // The same set of selector functions are present in both dom and selectors.
+  // For this reason, looking into DOM is representative of both groups.
+  const wrapperPropsList = Object.keys(DomElementWrapper.prototype);
+
+  // Every component has the same set of selector functions.
+  // For this reason, casting the function names into the CodeView component.
+  const findName = `find${componentNamePascalCase}` as "findCodeView";
+  const findAllName = wrapperPropsList.find((selector) => findAllRegex.test(selector)) as "findAllCodeViews";
+
+  return { findName, findAllName };
+}
+
+describe.each(Object.keys(components))("ElementWrapper selectors for %s component", (componentName) => {
+  const { findName, findAllName } = getComponentSelectors(componentName);
+
+  describe("dom wrapper", () => {
+    test(`${findName} returns the first ${componentName}`, () => {
+      const { container } = renderComponents(componentName);
+      const wrapper = createWrapperDom(container);
+      const element = wrapper[findName]()!.getElement();
+
+      expect(element).toHaveAttribute("data-name", "first item");
+    });
+
+    test(`${findAllName} returns all of the ${componentName} components`, () => {
+      const { container } = renderComponents(componentName);
+      const wrapper = createWrapperDom(container);
+      const elementNameAttributes = wrapper[findAllName]().map((component) =>
+        component!.getElement().getAttribute("data-name"),
+      );
+
+      expect(elementNameAttributes).toEqual(["first item", "second item"]);
+    });
+
+    test(`${findAllName} returns only the matching ${componentName} components, when a selector is specified`, () => {
+      const { container } = renderComponents(componentName, [
+        { "data-type": "first-type", "data-name": "first item" },
+        { "data-type": "second-type", "data-name": "second item" },
+        { "data-type": "second-type", "data-name": "third item" },
+      ]);
+      const wrapper = createWrapperDom(container);
+      const elementNameAttributes = wrapper[findAllName]("[data-type=second-type]").map((component) =>
+        component!.getElement().getAttribute("data-name"),
+      );
+
+      expect(elementNameAttributes).toEqual(["second item", "third item"]);
+    });
+  });
+
+  describe("selectors wrapper", () => {
+    test(`${findName} returns a selector that matches the ${componentName}`, () => {
+      const { container } = renderComponents(componentName);
+      const wrapper = createWrapperSelectors();
+      const selector = wrapper[findName]().toSelector();
+      const element = container.querySelector(selector);
+
+      expect(element).toHaveAttribute("data-name", "first item");
+    });
+
+    test(`${findAllName} returns a selector that matches the ${componentName} with nth-child index`, () => {
+      const { container } = renderComponents(componentName);
+      const wrapper = createWrapperSelectors();
+      const selector = wrapper[findAllName]().get(2).toSelector();
+      const element = container.querySelector(selector);
+
+      expect(element).toHaveAttribute("data-name", "second item");
+    });
+
+    test(`${findAllName} appends the specified selector to the default ${componentName} selectors`, () => {
+      const { container } = renderComponents(componentName, [
+        { "data-type": "first-type", "data-name": "first item" },
+        { "data-type": "second-type", "data-name": "second item" },
+      ]);
+      const wrapper = createWrapperSelectors();
+      const firstItemSelector = wrapper[findAllName]("[data-type=second-type]").get(1).toSelector();
+      const secondItemSelector = wrapper[findAllName]("[data-type=second-type]").get(2).toSelector();
+      const firstElement = container.querySelector(firstItemSelector);
+      const secondElement = container.querySelector(secondItemSelector);
+
+      expect(firstElement).toBeFalsy();
+      expect(secondElement).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds two `findAll[COMPONENT_NAME]s()` test utils selectors to each component wrapper.
Similar to: https://github.com/cloudscape-design/components/pull/3024

Depends on https://github.com/cloudscape-design/test-utils/pull/74

Related links, issue #, if available: **Test utils API improvements project**

### How has this been tested?

✅  Copies including the JSDocs and the pluralizations have been reviewed by the content team.
🧪 Unit tests added to both selectors and dom test utils.

Related links, issue #, if available: Test utils API improvements project

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
