### PR TITLE
fix: Fix line numbers incorrectly wrapping inside `word-break: break-word` parents

### DIFF
--- a/pages/code-view/with-line-numbers.page.tsx
+++ b/pages/code-view/with-line-numbers.page.tsx
@@ -17,6 +17,13 @@ export default function CodeViewPage() {
           content={`# Hello World`}
           actions={<Button ariaLabel="Copy code" iconName="copy"></Button>}
         />
+        {/* Wrapping should not be affected by the parent's word-break property. */}
+        <div style={{ wordBreak: "break-word" }}>
+          <CodeView
+            lineNumbers={true}
+            content={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => `This is line number #${i + 1}.`).join("\n")}
+          />
+        </div>
       </SpaceBetween>
     </ScreenshotArea>
   );

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -44,12 +44,13 @@ $color-background-code-view-dark: #282c34;
 }
 
 .line-number {
-  border-inline-end-color: cs.$color-border-divider-default;
   vertical-align: text-top;
+  white-space: nowrap;
   position: sticky;
   inset-inline-start: 0;
   border-inline-end-width: 1px;
   border-inline-end-style: solid;
+  border-inline-end-color: cs.$color-border-divider-default;
   padding-inline-start: cs.$space-static-xs;
   padding-inline-end: cs.$space-static-xs;
 


### PR DESCRIPTION
### Description

Pretty straightforward fix.

Okay, so... this component doesn't have a `styles-reset` mixin at the top. Not that it would have fixed this particular bug (which is why I didn't add it here), but adding one at this point also causes notable visual changes so I didn't want to mess with that. Just mentioning it.

Related links, issue #, if available: AWSUI-60310

### How has this been tested?

Created a visual page for it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
