### PR TITLE
chore: Skip documenter snapshots

### DIFF
--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "vitest";
 // @ts-expect-error no types here
 import apiDocs from "../../lib/components/internal/api-docs/components";
 
-test("definition for code-view matches the snapshot", () => {
+test.skip("definition for code-view matches the snapshot", () => {
   const definition = apiDocs["code-view"];
   expect(definition).toMatchSnapshot();
 });


### PR DESCRIPTION
### Description

Preparing this change to land: https://github.com/cloudscape-design/documenter/pull/58

After that change is landed I will enable and re-generate snapshots

Related links, issue #, if available: n/a

### How has this been tested?

Test change only

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
