### PR TITLE
chore: refactor and re-enable documenter snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "@typescript-eslint/parser": "^5.48.0",
         "@vitejs/plugin-react": "^4.3.4",
-        "@vitest/coverage-v8": "^3.0.7",
+        "@vitest/coverage-v8": "^3.1.1",
         "chokidar-cli": "^3.0.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^8.10.0",
@@ -67,7 +67,7 @@
         "stylelint-use-logical": "^2.1.2",
         "typescript": "4.9.4",
         "vite": "^6.2.5",
-        "vitest": "^3.0.7"
+        "vitest": "^3.1.1"
       },
       "peerDependencies": {
         "@cloudscape-design/components": "^3",
@@ -1073,170 +1073,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@cloudscape-design/browser-test-tools": {
-      "version": "3.0.88",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.88.tgz",
-      "integrity": "sha512-4/tfkzq/itn0PvFCuMcYYy9ScguOx2n0mRGKuZ6F2y01kuuSbxlrTv2r4MmB8MZ1QZJB9YwzBVT7O/ulmnDctg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-device-farm": "^3.623.0",
-        "@types/pngjs": "^6.0.4",
-        "@wdio/globals": "^9.7.0",
-        "@wdio/types": "^9.6.3",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "wait-on": "^8.0.3",
-        "webdriverio": "^9.7.0"
-      }
-    },
-    "node_modules/@cloudscape-design/build-tools": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/build-tools/-/build-tools-3.0.8.tgz",
-      "integrity": "sha512-BgoA9RU8fES40mGBkgDfIxRrmRLpqvEb/+8fS/plM96gkmD3lzICi4YlWifHlHccQ5VpqFs5ahiaIoblZ8ROkQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "stylelint": "^16.8.1"
-      }
-    },
-    "node_modules/@cloudscape-design/collection-hooks": {
-      "version": "1.0.68",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.68.tgz",
-      "integrity": "sha512-Zn7H5RllRvx9tawKLYUXC8npTBP3rQtiNyFpDCUtElsfOYkpnBoIAcKChixAiIM96OLYbaETJy7o/yq7lTHaSQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/@cloudscape-design/component-toolkit": {
-      "version": "1.0.0-beta.93",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.93.tgz",
-      "integrity": "sha512-JX41EXJ9x3weN1GJ0yp8ty7i4SMJYPrtCSQ2xy2tkXHczvVnSU7GEUfIxVBgHxDlwC4Mpnz2iDmXMwLsh9aN1Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.3.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@cloudscape-design/components": {
-      "version": "3.0.938",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.938.tgz",
-      "integrity": "sha512-FLUC4CED7GYVCpCulaSK0NuVhVCuWv49jV/tCZux6VmCwEiCKWi3x+hsCAT3x5UXFBrLabNMlNMvMg8AKecsrA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cloudscape-design/collection-hooks": "^1.0.0",
-        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
-        "@cloudscape-design/test-utils-core": "^1.0.0",
-        "@cloudscape-design/theming-runtime": "^1.0.0",
-        "@dnd-kit/core": "^6.0.8",
-        "@dnd-kit/sortable": "^7.0.2",
-        "@dnd-kit/utilities": "^3.2.1",
-        "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.34.0",
-        "balanced-match": "^1.0.2",
-        "clsx": "^1.1.0",
-        "d3-shape": "^1.3.7",
-        "date-fns": "^2.25.0",
-        "intl-messageformat": "^10.3.1",
-        "mnth": "^2.0.0",
-        "react-keyed-flatten-children": "^2.2.1",
-        "react-transition-group": "^4.4.2",
-        "tslib": "^2.4.0",
-        "weekstart": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
-    },
-    "node_modules/@cloudscape-design/design-tokens": {
-      "version": "3.0.53",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/design-tokens/-/design-tokens-3.0.53.tgz",
-      "integrity": "sha512-YNg7X3/lAzUk+W1iktNbnN6iHcUzmLmTLGV1v40+mx6jBvpwszoQodTQGUaHvxC826yJ6fS50liLEPvvIDv3sg==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@cloudscape-design/documenter": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/documenter/-/documenter-1.0.32.tgz",
-      "integrity": "sha512-nL+hNJey8BIu2dfHFIe/thz5kXiExzz5Bh3yFkfiaL39C4BxxPxgxGDqQnc7xd78sc+cYkazR6PyfqTgz8AR+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "change-case": "^4.1.1",
-        "micromatch": "^4.0.8",
-        "pathe": "^1.1.2",
-        "typedoc": "~0.19.2"
-      }
-    },
-    "node_modules/@cloudscape-design/global-styles": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.39.tgz",
-      "integrity": "sha512-S8cQyc41/7Y6FKCftQ/MbvBKOnmtUlh6heLAgOoqliWqqypahwaRee44Hrvi57/mFrGIRGj/EOd2k4xJo1fepg==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@cloudscape-design/test-utils-converter": {
-      "version": "1.0.54",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-converter/-/test-utils-converter-1.0.54.tgz",
-      "integrity": "sha512-fHvDwJjPn2BMeDdj9Y74XR7dNW5jVJL8vPmvWVnj4wyPiHnFktT0Bed1QiJu0neY3KXrHu00Ukg4VwYa6eUVKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.16.0",
-        "@babel/plugin-syntax-decorators": "^7.16.0",
-        "@babel/plugin-syntax-typescript": "^7.16.0",
-        "glob": "^7.2.0"
-      }
-    },
-    "node_modules/@cloudscape-design/test-utils-core": {
-      "version": "1.0.54",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.54.tgz",
-      "integrity": "sha512-EM/U5/t8D4yKwFYL2ltlyAoqIb+b0r1kNW0dMvMwphmYYC6z1Bunl7L9JcHYhhX8MYC+5l2A3LuzznK7+Os4Zg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.8.0",
-        "css.escape": "^1.5.1"
-      }
-    },
-    "node_modules/@cloudscape-design/theming-build": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-build/-/theming-build-1.0.80.tgz",
-      "integrity": "sha512-dpQxxTu7o5nxD+FloIj3E+3LuvdaiRI/LTwm4oxzgCR5c4y2Mh9rgp2XF+ka+3BuPXkCB5SN308NlMCtBL21Ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "autoprefixer": "^10.4.8",
-        "glob": "^7.2.3",
-        "jsonschema": "^1.4.1",
-        "loader-utils": "^3.2.1",
-        "lodash": "^4.17.21",
-        "postcss": "^8.4.31",
-        "postcss-discard-empty": "^6.0.0",
-        "postcss-inline-svg": "^6.0.0",
-        "postcss-modules": "^6.0.0",
-        "sass": "^1.77.8",
-        "string-hash": "^1.1.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@cloudscape-design/theming-runtime": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.73.tgz",
-      "integrity": "sha512-K7gmOwCgFvMPBaFN+hC7XYzcOFct2ajSYByU+rDfFNARz3zgY0gYlV/CO16fcyzDK60Fu5Lwp+3wjLRrpvDQqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -4149,9 +3985,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.7.tgz",
-      "integrity": "sha512-Av8WgBJLTrfLOer0uy3CxjlVuWK4CzcLBndW1Nm2vI+3hZ2ozHututkfc7Blu1u6waeQ7J8gzPK/AsBRnWA5mQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.1.tgz",
+      "integrity": "sha512-MgV6D2dhpD6Hp/uroUoAIvFqA8AuvXEFBC2eepG3WFc1pxTfdk1LEqqkWoWhjz+rytoqrnUUCdf6Lzco3iHkLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4164,7 +4000,7 @@
         "istanbul-reports": "^3.1.7",
         "magic-string": "^0.30.17",
         "magicast": "^0.3.5",
-        "std-env": "^3.8.0",
+        "std-env": "^3.8.1",
         "test-exclude": "^7.0.1",
         "tinyrainbow": "^2.0.0"
       },
@@ -4172,8 +4008,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.0.7",
-        "vitest": "3.0.7"
+        "@vitest/browser": "3.1.1",
+        "vitest": "3.1.1"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4182,14 +4018,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.7.tgz",
-      "integrity": "sha512-QP25f+YJhzPfHrHfYHtvRn+uvkCFCqFtW9CktfBxmB+25QqWsx7VB2As6f4GmwllHLDhXNHvqedwhvMmSnNmjw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+      "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.7",
-        "@vitest/utils": "3.0.7",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -4198,13 +4034,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.7.tgz",
-      "integrity": "sha512-qui+3BLz9Eonx4EAuR/i+QlCX6AUZ35taDQgwGkK/Tw6/WgwodSrjN1X2xf69IA/643ZX5zNKIn2svvtZDrs4w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+      "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.7",
+        "@vitest/spy": "3.1.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -4225,9 +4061,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.7.tgz",
-      "integrity": "sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4238,13 +4074,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.7.tgz",
-      "integrity": "sha512-WeEl38Z0S2ZcuRTeyYqaZtm4e26tq6ZFqh5y8YD9YxfWuu0OFiGFUbnxNynwLjNRHPsXyee2M9tV7YxOTPZl2g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+      "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.7",
+        "@vitest/utils": "3.1.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4259,13 +4095,13 @@
       "license": "MIT"
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.7.tgz",
-      "integrity": "sha512-eqTUryJWQN0Rtf5yqCGTQWsCFOQe4eNz5Twsu21xYEcnFJtMU5XvmG0vgebhdLlrHQTSq5p8vWHJIeJQV8ovsA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+      "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.7",
+        "@vitest/pretty-format": "3.1.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -4281,9 +4117,9 @@
       "license": "MIT"
     },
     "node_modules/@vitest/spy": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.7.tgz",
-      "integrity": "sha512-4T4WcsibB0B6hrKdAZTM37ekuyFZt2cGbEGd2+L0P8ov15J1/HUsUaqkXEQPNAWr4BtPPe1gI+FYfMHhEKfR8w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+      "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4294,13 +4130,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.7.tgz",
-      "integrity": "sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.7",
+        "@vitest/pretty-format": "3.1.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -15219,9 +15055,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.7.tgz",
-      "integrity": "sha512-2fX0QwX4GkkkpULXdT1Pf4q0tC1i1lFOyseKoonavXUNlQ77KpW2XqBGGNIm/J4Ows4KxgGJzDguYVPKwG/n5A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+      "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15249,31 +15085,31 @@
       "license": "MIT"
     },
     "node_modules/vitest": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.7.tgz",
-      "integrity": "sha512-IP7gPK3LS3Fvn44x30X1dM9vtawm0aesAa2yBIZ9vQf+qB69NXC5776+Qmcr7ohUXIQuLhk7xQR0aSUIDPqavg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+      "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.0.7",
-        "@vitest/mocker": "3.0.7",
-        "@vitest/pretty-format": "^3.0.7",
-        "@vitest/runner": "3.0.7",
-        "@vitest/snapshot": "3.0.7",
-        "@vitest/spy": "3.0.7",
-        "@vitest/utils": "3.0.7",
+        "@vitest/expect": "3.1.1",
+        "@vitest/mocker": "3.1.1",
+        "@vitest/pretty-format": "^3.1.1",
+        "@vitest/runner": "3.1.1",
+        "@vitest/snapshot": "3.1.1",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
-        "expect-type": "^1.1.0",
+        "expect-type": "^1.2.0",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
-        "std-env": "^3.8.0",
+        "std-env": "^3.8.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.7",
+        "vite-node": "3.1.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -15289,8 +15125,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.0.7",
-        "@vitest/ui": "3.0.7",
+        "@vitest/browser": "3.1.1",
+        "@vitest/ui": "3.1.1",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^3.0.7",
+    "@vitest/coverage-v8": "^3.1.1",
     "chokidar-cli": "^3.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^8.10.0",
@@ -127,7 +127,7 @@
     "stylelint-use-logical": "^2.1.2",
     "typescript": "4.9.4",
     "vite": "^6.2.5",
-    "vitest": "^3.0.7"
+    "vitest": "^3.1.1"
   },
   "//": "ensure that typedoc uses typescript 4.9.4. It prints a warning, but works",
   "overrides": {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`definition for code-view matches the snapshot 1`] = `
+exports[`definition for 'code-view' matches the snapshot 1`] = `
 {
   "events": [],
   "functions": [],
@@ -26,22 +26,33 @@ exports[`definition for code-view matches the snapshot 1`] = `
     },
     {
       "description": "A function to perform custom syntax highlighting.",
+      "inlineType": {
+        "name": "(code: string) => React.ReactNode",
+        "parameters": [
+          {
+            "name": "code",
+            "type": "string",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
       "name": "highlight",
       "optional": true,
-      "type": "(code: string) => React.ReactNode",
+      "type": "((code: string) => React.ReactNode)",
     },
     {
       "description": "Controls the display of line numbers.
-Defaults to \`false\`.
-",
+
+Defaults to \`false\`.",
       "name": "lineNumbers",
       "optional": true,
       "type": "boolean",
     },
     {
       "description": "Controls whether line-wrapping is enabled when content would overflow the component.
-Defaults to \`false\`.
-",
+
+Defaults to \`false\`.",
       "name": "wrapLines",
       "optional": true,
       "type": "boolean",

--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -5,7 +5,6 @@ import { expect, test } from "vitest";
 // @ts-expect-error no types here
 import apiDocs from "../../lib/components/internal/api-docs/components";
 
-test.skip("definition for code-view matches the snapshot", () => {
-  const definition = apiDocs["code-view"];
+test.each(Object.entries(apiDocs))("definition for $0 matches the snapshot", (name, definition) => {
   expect(definition).toMatchSnapshot();
 });


### PR DESCRIPTION
### Description

Re-enable snapshot tests after https://github.com/cloudscape-design/documenter/pull/58 is released

Related links, issue #, if available: n/a

### How has this been tested?

Build passes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
