### PR TITLE
fix: Use semantic table to show line numbers to assistive technology

### DIFF
--- a/pages/code-view/with-line-numbers.page.tsx
+++ b/pages/code-view/with-line-numbers.page.tsx
@@ -7,8 +7,8 @@ import { CodeView, CodeViewProps } from "../../lib/components";
 import { ScreenshotArea } from "../screenshot-area";
 
 const i18nStrings: CodeViewProps.I18nStrings = {
-  lineLabel: `Line number`,
-  contentLabel: `Content`,
+  lineNumberLabel: `Line number`,
+  codeLabel: `Code`,
 };
 
 export default function CodeViewPage() {

--- a/pages/code-view/with-line-numbers.page.tsx
+++ b/pages/code-view/with-line-numbers.page.tsx
@@ -3,17 +3,24 @@
 
 import { Button, SpaceBetween } from "@cloudscape-design/components";
 
-import { CodeView } from "../../lib/components";
+import { CodeView, CodeViewProps } from "../../lib/components";
 import { ScreenshotArea } from "../screenshot-area";
+
+const i18nStrings: CodeViewProps.I18nStrings = {
+  lineLabel: `Line number`,
+  contentLabel: `Content`,
+};
+
 export default function CodeViewPage() {
   return (
     <ScreenshotArea>
       <h1>Code View</h1>
       <SpaceBetween direction="vertical" size="l">
-        <CodeView lineNumbers={true} content={`# Hello World`} />
-        <CodeView lineNumbers={true} content={`# Hello World\n\nThis is Cloudscape.`} />
+        <CodeView lineNumbers={true} i18nStrings={i18nStrings} content={`# Hello World`} />
+        <CodeView lineNumbers={true} i18nStrings={i18nStrings} content={`# Hello World\n\nThis is Cloudscape.`} />
         <CodeView
           lineNumbers={true}
+          i18nStrings={i18nStrings}
           content={`# Hello World`}
           actions={<Button ariaLabel="Copy code" iconName="copy"></Button>}
         />
@@ -21,6 +28,7 @@ export default function CodeViewPage() {
         <div style={{ wordBreak: "break-word" }}>
           <CodeView
             lineNumbers={true}
+            i18nStrings={i18nStrings}
             content={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => `This is line number #${i}.`).join("\n")}
           />
         </div>

--- a/pages/code-view/with-line-numbers.page.tsx
+++ b/pages/code-view/with-line-numbers.page.tsx
@@ -21,7 +21,7 @@ export default function CodeViewPage() {
         <div style={{ wordBreak: "break-word" }}>
           <CodeView
             lineNumbers={true}
-            content={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => `This is line number #${i + 1}.`).join("\n")}
+            content={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => `This is line number #${i}.`).join("\n")}
           />
         </div>
       </SpaceBetween>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -43,6 +43,28 @@ exports[`definition for 'code-view' matches the snapshot 1`] = `
       "type": "((code: string) => React.ReactNode)",
     },
     {
+      "description": "An object containing all the necessary localized strings required by the component.",
+      "inlineType": {
+        "name": "CodeViewProps.I18nStrings",
+        "properties": [
+          {
+            "name": "contentLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "lineLabel",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "i18nStrings",
+      "optional": true,
+      "type": "CodeViewProps.I18nStrings",
+    },
+    {
       "description": "Controls the display of line numbers.
 
 Defaults to \`false\`.",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -43,7 +43,10 @@ exports[`definition for 'code-view' matches the snapshot 1`] = `
       "type": "((code: string) => React.ReactNode)",
     },
     {
-      "description": "An object containing all the necessary localized strings required by the component.",
+      "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+
+* \`lineNumberLabel\` - Label for the column that displays line numbers (when line numbers are visible)
+* \`codeLabel\` - Label for the column that displays the code content (when line numbers are visible)",
       "inlineType": {
         "name": "CodeViewProps.I18nStrings",
         "properties": [

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -48,12 +48,12 @@ exports[`definition for 'code-view' matches the snapshot 1`] = `
         "name": "CodeViewProps.I18nStrings",
         "properties": [
           {
-            "name": "contentLabel",
+            "name": "codeLabel",
             "optional": true,
             "type": "string",
           },
           {
-            "name": "lineLabel",
+            "name": "lineNumberLabel",
             "optional": true,
             "type": "string",
           },

--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -23,7 +23,7 @@ describe("CodeView", () => {
     render(<CodeView content={`# Hello World\n\nThis is a markdown example.`}></CodeView>);
     const wrapper = createWrapper()!.findCodeView()!;
     const content = wrapper.findContent();
-    expect(content.getElement()).toHaveTextContent("# Hello World This is a markdown example.");
+    expect(content.getElement()).toHaveTextContent("Line 1 # Hello World Line 2 Line 3 This is a markdown example.");
   });
 
   test("correctly renders copy button slot", () => {

--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -23,7 +23,7 @@ describe("CodeView", () => {
     render(<CodeView content={`# Hello World\n\nThis is a markdown example.`}></CodeView>);
     const wrapper = createWrapper()!.findCodeView()!;
     const content = wrapper.findContent();
-    expect(content.getElement()).toHaveTextContent("Line 1 # Hello World Line 2 Line 3 This is a markdown example.");
+    expect(content.getElement()).toHaveTextContent("1. # Hello World 2. 3. This is a markdown example.");
   });
 
   test("correctly renders copy button slot", () => {

--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -30,7 +30,7 @@ describe("CodeView", () => {
     render(
       <CodeView
         lineNumbers={true}
-        i18nStrings={{ lineLabel: "Line number", contentLabel: "Content" }}
+        i18nStrings={{ lineNumberLabel: "Line number", codeLabel: "Code" }}
         content={`# Hello World\n\nThis is a markdown example.`}
       />,
     );
@@ -40,7 +40,7 @@ describe("CodeView", () => {
     const lineNumberColumn = wrapper.find("th:nth-child(1)")!.getElement();
     expect(lineNumberColumn).toHaveTextContent("Line number");
     const contentColumn = wrapper.find("th:nth-child(2)")!.getElement();
-    expect(contentColumn).toHaveTextContent("Content");
+    expect(contentColumn).toHaveTextContent("Code");
     const lineNumberCell = wrapper.find("td:nth-child(1)")!.getElement();
     expect(lineNumberCell).not.toHaveAttribute("aria-hidden", "true");
   });

--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -23,7 +23,26 @@ describe("CodeView", () => {
     render(<CodeView content={`# Hello World\n\nThis is a markdown example.`}></CodeView>);
     const wrapper = createWrapper()!.findCodeView()!;
     const content = wrapper.findContent();
-    expect(content.getElement()).toHaveTextContent("1. # Hello World 2. 3. This is a markdown example.");
+    expect(content.getElement()).toHaveTextContent("# Hello World This is a markdown example.");
+  });
+
+  test("correctly renders table markup with line numbers", () => {
+    render(
+      <CodeView
+        lineNumbers={true}
+        i18nStrings={{ lineLabel: "Line number", contentLabel: "Content" }}
+        content={`# Hello World\n\nThis is a markdown example.`}
+      />,
+    );
+    const wrapper = createWrapper()!.findCodeView()!;
+    const table = wrapper.find("table")!.getElement();
+    expect(table).not.toHaveAttribute("role");
+    const lineNumberColumn = wrapper.find("th:nth-child(1)")!.getElement();
+    expect(lineNumberColumn).toHaveTextContent("Line number");
+    const contentColumn = wrapper.find("th:nth-child(2)")!.getElement();
+    expect(contentColumn).toHaveTextContent("Content");
+    const lineNumberCell = wrapper.find("td:nth-child(1)")!.getElement();
+    expect(lineNumberCell).not.toHaveAttribute("aria-hidden", "true");
   });
 
   test("correctly renders copy button slot", () => {

--- a/src/code-view/interfaces.ts
+++ b/src/code-view/interfaces.ts
@@ -50,7 +50,7 @@ export interface CodeViewProps {
 
 export namespace CodeViewProps {
   export interface I18nStrings {
-    lineLabel?: string;
-    contentLabel?: string;
+    lineNumberLabel?: string;
+    codeLabel?: string;
   }
 }

--- a/src/code-view/interfaces.ts
+++ b/src/code-view/interfaces.ts
@@ -39,7 +39,18 @@ export interface CodeViewProps {
 
   /**
    * A function to perform custom syntax highlighting.
-   *
    */
   highlight?: (code: string) => React.ReactNode;
+
+  /**
+   * An object containing all the necessary localized strings required by the component.
+   */
+  i18nStrings?: CodeViewProps.I18nStrings;
+}
+
+export namespace CodeViewProps {
+  export interface I18nStrings {
+    lineLabel?: string;
+    contentLabel?: string;
+  }
 }

--- a/src/code-view/interfaces.ts
+++ b/src/code-view/interfaces.ts
@@ -43,7 +43,10 @@ export interface CodeViewProps {
   highlight?: (code: string) => React.ReactNode;
 
   /**
-   * An object containing all the necessary localized strings required by the component.
+   * An object containing all the necessary localized strings required by the component. The object should contain:
+   *
+   * * `lineNumberLabel` - Label for the column that displays line numbers (when line numbers are visible)
+   * * `codeLabel` - Label for the column that displays the code content (when line numbers are visible)
    */
   i18nStrings?: CodeViewProps.I18nStrings;
 }

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -66,7 +66,7 @@ export function InternalCodeView({
     >
       <div className={styles["scroll-container"]} ref={containerRef}>
         <table
-          role={lineNumbers ? "table" : "presentation"}
+          role="presentation"
           className={clsx(
             styles["code-table"],
             actions && styles["code-table-with-actions"],
@@ -77,26 +77,19 @@ export function InternalCodeView({
             <col style={{ width: 1 } /* shrink to fit content */} />
             <col style={{ width: "auto" }} />
           </colgroup>
-          {lineNumbers && (
-            <thead className={styles["table-header"]}>
-              <tr>
-                <th>Row number</th>
-                <th>Content</th>
-              </tr>
-            </thead>
-          )}
           <tbody>
             {Children.map(codeElement.props.children, (child, index) => {
               return (
                 <tr key={index}>
                   {lineNumbers && (
-                    <td className={clsx(styles["line-number"], styles.unselectable)}>
+                    <td className={clsx(styles["line-number"], styles.unselectable)} aria-hidden={true}>
                       <Box variant="code" color="text-status-inactive" fontSize="body-m">
                         {index + 1}
                       </Box>
                     </td>
                   )}
                   <td className={styles["code-line"]}>
+                    <span className={styles["screenreader-only"]}>Line {index + 1} </span>
                     <Box variant="code" fontSize="body-m">
                       <span
                         className={clsx(

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -89,7 +89,7 @@ export function InternalCodeView({
                     </td>
                   )}
                   <td className={styles["code-line"]}>
-                    <span className={styles["screenreader-only"]}>Line {index + 1} </span>
+                    <span className={styles["screenreader-only"]}>{index + 1}. </span>
                     <Box variant="code" fontSize="body-m">
                       <span
                         className={clsx(

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -48,7 +48,7 @@ export function InternalCodeView({
   const darkMode = useCurrentMode(containerRef) === "dark";
 
   const regionProps = ariaLabel || ariaLabelledby ? { role: "region" } : {};
-  const accessibleLineNumbers = lineNumbers && i18nStrings?.lineLabel && i18nStrings?.contentLabel;
+  const accessibleLineNumbers = lineNumbers && i18nStrings?.lineNumberLabel && i18nStrings?.codeLabel;
 
   // Create tokenized React nodes of the content.
   const code = highlight ? highlight(content) : textHighlight(content);
@@ -82,8 +82,8 @@ export function InternalCodeView({
           {accessibleLineNumbers && (
             <thead className={styles["screenreader-only"]}>
               <tr>
-                {lineNumbers && <th>{i18nStrings.lineLabel}</th>}
-                <th>{i18nStrings.contentLabel}</th>
+                {lineNumbers && <th>{i18nStrings.lineNumberLabel}</th>}
+                <th>{i18nStrings.codeLabel}</th>
               </tr>
             </thead>
           )}

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -39,6 +39,7 @@ export function InternalCodeView({
   highlight,
   ariaLabel,
   ariaLabelledby,
+  i18nStrings,
   __internalRootRef = null,
   ...props
 }: InternalCodeViewProps) {
@@ -47,6 +48,7 @@ export function InternalCodeView({
   const darkMode = useCurrentMode(containerRef) === "dark";
 
   const regionProps = ariaLabel || ariaLabelledby ? { role: "region" } : {};
+  const accessibleLineNumbers = lineNumbers && i18nStrings?.lineLabel && i18nStrings?.contentLabel;
 
   // Create tokenized React nodes of the content.
   const code = highlight ? highlight(content) : textHighlight(content);
@@ -66,7 +68,7 @@ export function InternalCodeView({
     >
       <div className={styles["scroll-container"]} ref={containerRef}>
         <table
-          role="presentation"
+          role={!accessibleLineNumbers ? "presentation" : undefined}
           className={clsx(
             styles["code-table"],
             actions && styles["code-table-with-actions"],
@@ -77,19 +79,29 @@ export function InternalCodeView({
             <col style={{ width: 1 } /* shrink to fit content */} />
             <col style={{ width: "auto" }} />
           </colgroup>
+          {accessibleLineNumbers && (
+            <thead className={styles["screenreader-only"]}>
+              <tr>
+                {lineNumbers && <th>{i18nStrings.lineLabel}</th>}
+                <th>{i18nStrings.contentLabel}</th>
+              </tr>
+            </thead>
+          )}
           <tbody>
             {Children.map(codeElement.props.children, (child, index) => {
               return (
                 <tr key={index}>
                   {lineNumbers && (
-                    <td className={clsx(styles["line-number"], styles.unselectable)} aria-hidden={true}>
+                    <td
+                      className={clsx(styles["line-number"], styles.unselectable)}
+                      aria-hidden={!accessibleLineNumbers}
+                    >
                       <Box variant="code" color="text-status-inactive" fontSize="body-m">
                         {index + 1}
                       </Box>
                     </td>
                   )}
                   <td className={styles["code-line"]}>
-                    <span className={styles["screenreader-only"]}>{index + 1}. </span>
                     <Box variant="code" fontSize="body-m">
                       <span
                         className={clsx(

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -66,7 +66,7 @@ export function InternalCodeView({
     >
       <div className={styles["scroll-container"]} ref={containerRef}>
         <table
-          role="presentation"
+          role={lineNumbers ? "table" : "presentation"}
           className={clsx(
             styles["code-table"],
             actions && styles["code-table-with-actions"],
@@ -77,12 +77,20 @@ export function InternalCodeView({
             <col style={{ width: 1 } /* shrink to fit content */} />
             <col style={{ width: "auto" }} />
           </colgroup>
+          {lineNumbers && (
+            <thead className={styles["table-header"]}>
+              <tr>
+                <th>Row number</th>
+                <th>Content</th>
+              </tr>
+            </thead>
+          )}
           <tbody>
             {Children.map(codeElement.props.children, (child, index) => {
               return (
                 <tr key={index}>
                   {lineNumbers && (
-                    <td className={clsx(styles["line-number"], styles.unselectable)} aria-hidden={true}>
+                    <td className={clsx(styles["line-number"], styles.unselectable)}>
                       <Box variant="code" color="text-status-inactive" fontSize="body-m">
                         {index + 1}
                       </Box>

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -14,7 +14,7 @@ $color-background-code-view-dark: #282c34;
   border-start-end-radius: cs.$border-radius-tiles;
   border-end-start-radius: cs.$border-radius-tiles;
   border-end-end-radius: cs.$border-radius-tiles;
-  
+
   background-color: $color-background-code-view-light;
   :global(.awsui-dark-mode) &,
   :global(.awsui-polaris-dark-mode) & {
@@ -41,6 +41,12 @@ $color-background-code-view-dark: #282c34;
 
 .code-table-with-actions.code-table-with-line-wrapping {
   padding-inline-end: cs.$space-static-xxl;
+}
+
+.table-header {
+  position: absolute;
+  inset-block-start: -9999px;
+  inset-inline-start: -9999px;
 }
 
 .line-number {

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -43,7 +43,7 @@ $color-background-code-view-dark: #282c34;
   padding-inline-end: cs.$space-static-xxl;
 }
 
-.table-header {
+.screenreader-only {
   position: absolute;
   inset-block-start: -9999px;
   inset-inline-start: -9999px;


### PR DESCRIPTION
### Description

Based on further discussion with the accessibility specialists, this seemed to be the best way to go. We already have a tabular structure, so it makes sense for it to be navigable as a table as well (plus, tables are just easy to navigate). That visual change is intentional; it previously started with "This is line number 2" on the first line.

Code view (also other side packages) doesn't have support for I18nProvider, so this won't enable itself unless the strings are completely provided. They _should_ support I18nProvider, of course, but that's a matter for a different time. 

Related links, issue #, if available: AWSUI-60236

### How has this been tested?

Updated unit tests, tested on VoiceOver and NVDA manually as well. But try it out yourself! Enable VoiceOver, enter the table, and use VO+Arrow Keys. (VO = Control + Option).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
