### PR TITLE
chore: Migrate to the new documenter API

### DIFF
--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -2,41 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import path from "node:path";
 
-import { documentComponents, documentTestUtils } from "@cloudscape-design/documenter";
+import { documentTestUtils, writeComponentsDocumentation } from "@cloudscape-design/documenter";
 
-import { listPublicDirs, writeSourceFile } from "./utils.js";
+import { writeSourceFile } from "./utils.js";
 
-const publicDirs = listPublicDirs("src");
 const targetDir = "lib/components/internal/api-docs";
 
 componentDocs();
 testUtilDocs();
 
-function validatePublicFiles(definitionFiles) {
-  for (const publicDir of publicDirs) {
-    if (!definitionFiles.includes(publicDir)) {
-      throw new Error(`Directory src/${publicDir} does not have a corresponding API definition`);
-    }
-  }
-}
-
 function componentDocs() {
-  const definitions = documentComponents({
+  writeComponentsDocumentation({
+    outDir: path.join(targetDir, "components"),
     tsconfigPath: path.resolve("tsconfig.json"),
     publicFilesGlob: "src/*/index.tsx",
   });
-  const outDir = path.join(targetDir, "components");
-  for (const definition of definitions) {
-    writeSourceFile(
-      path.join(outDir, definition.dashCaseName + ".js"),
-      `module.exports = ${JSON.stringify(definition, null, 2)};`,
-    );
-  }
-  const indexContent = `module.exports = {
-    ${definitions.map((definition) => `${JSON.stringify(definition.dashCaseName)}:require('./${definition.dashCaseName}')`).join(",\n")}
-  }`;
-  writeSourceFile(path.join(outDir, "index.js"), indexContent);
-  validatePublicFiles(definitions.map((def) => def.dashCaseName));
 }
 
 function testUtilDocs() {

--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
 
-// @ts-expect-error no types here
 import apiDocs from "../../lib/components/internal/api-docs/components";
 
-test.each(Object.entries(apiDocs))("definition for $0 matches the snapshot", (name, definition) => {
+test.each(Object.entries(apiDocs))("definition for $0 matches the snapshot", (_name, definition) => {
   expect(definition).toMatchSnapshot();
 });


### PR DESCRIPTION
### Description

Same as https://github.com/cloudscape-design/components/pull/3475 and https://github.com/cloudscape-design/chat-components/pull/72 but for this package

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
