### PR TITLE
chore: Allow triggering of release workflow via webhook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@
 name: Release
 
 on:
+  repository_dispatch:
+    types: [run-release]
   push:
     branches:
       - main

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
 
 env:
   VISUAL_REGRESSION_SNAPSHOT_DIRECTORY: "__image_snapshots__"
@@ -15,7 +18,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    if: github.event.ref != 'refs/heads/main'
+    if: (github.event.ref || github.event.workflow_run.head_branch) != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -44,7 +47,7 @@ jobs:
   update:
     name: Update Snapshots
     runs-on: ubuntu-latest
-    if: github.event.ref == 'refs/heads/main'
+    if: (github.event.ref || github.event.workflow_run.head_branch) != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### Description

Allow this repo to be re-released when main components repo has changes

Related links, issue #, if available: n/a

### How has this been tested?

Based on testing in chat-components repo

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
