### PR TITLE
refactor: remove unnecessary Fragment wrapping

### DIFF
--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Children, createElement, Fragment, ReactElement, useMemo, useRef } from "react";
+import { Children, ReactElement, useMemo, useRef } from "react";
 import clsx from "clsx";
 
 import { useCurrentMode } from "@cloudscape-design/component-toolkit/internal";
@@ -56,9 +56,7 @@ export function InternalCodeView({
 
   // Memoize tokenized React nodes to avoid re-running highlight on every render.
   const code = useMemo(() => (highlight ? highlight(content) : textHighlight(content)), [content, highlight]);
-  // Create elements from the nodes.
-  const codeElementWrapper: ReactElement = createElement(Fragment, null, code);
-  const codeElement = Children.only(codeElementWrapper.props.children);
+  const codeElement = Children.only(code) as ReactElement;
 
   return (
     <div


### PR DESCRIPTION
### Description

`Children.only()` already validates that the `highlight` result is a single element. Wrapping that result in a `Fragment` first, only to read `.props.children` back off the wrapper, is a no-op:

```diff
-  const codeElementWrapper: ReactElement = createElement(Fragment, null, code);
-  const codeElement = Children.only(codeElementWrapper.props.children);
+  const codeElement = Children.only(code) as ReactElement;
```

The `Children.only()` call is kept deliberately. `CodeViewProps.highlight` is typed `(code: string) => React.ReactNode`, so a consumer can return a string, an array, or a fragment. `Children.only()` turns those cases into a clear error rather than silently rendering nothing when the render path reads `codeElement.props.children`. The old code got its `ReactElement` typing implicitly from the Fragment wrapper, so the explicit cast replaces that.

No behavior change.

### How has this been tested?

Existing unit tests pass (51 tests). Type-checked, linted, and verified in the dev server that the demos render unchanged.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
