### PR TITLE
fix: remove trailing newline after last rendered line

### DIFF
--- a/src/code-view/__tests__/code-view.test.tsx
+++ b/src/code-view/__tests__/code-view.test.tsx
@@ -14,16 +14,24 @@ describe("CodeView", () => {
     cleanup();
   });
   test("correctly renders simple content", () => {
-    render(<CodeView content={"Hello World"}></CodeView>);
-    const wrapper = createWrapper()!.findCodeView();
-    expect(wrapper!.findContent().getElement()).toHaveTextContent("Hello World");
+    const input = "Hello World";
+    render(<CodeView content={input}></CodeView>);
+    const wrapper = createWrapper()!.findCodeView()!;
+    expect(wrapper.findContent().getElement().textContent).toBe(input);
   });
 
   test("correctly renders multi line content", () => {
-    render(<CodeView content={`# Hello World\n\nThis is a markdown example.`}></CodeView>);
+    const input = `# Hello World\n\nThis is a markdown example.`;
+    render(<CodeView content={input}></CodeView>);
     const wrapper = createWrapper()!.findCodeView()!;
-    const content = wrapper.findContent();
-    expect(content.getElement()).toHaveTextContent("# Hello World This is a markdown example.");
+    expect(wrapper.findContent().getElement().textContent).toBe(input);
+  });
+
+  test("preserves a trailing newline when present in the input", () => {
+    const input = "a\nb\n";
+    render(<CodeView content={input}></CodeView>);
+    const wrapper = createWrapper()!.findCodeView()!;
+    expect(wrapper.findContent().getElement().textContent).toBe(input);
   });
 
   test("correctly renders table markup with line numbers", () => {
@@ -100,6 +108,13 @@ describe("CodeView", () => {
     expect(getByText(element, "hello")).toHaveClass("ace_identifier");
     expect(getByText(element, "string")).toHaveClass("ace_type");
     expect(getByText(element, '"world"')).toHaveClass("ace_string");
+  });
+
+  test("renders highlighted content without trailing newline", () => {
+    const input = 'const hello: string = "world";';
+    render(<CodeView content={input} highlight={typescriptHighlightRules}></CodeView>);
+    const wrapper = createWrapper()!.findCodeView()!;
+    expect(wrapper.findContent().getElement().textContent).toBe(input);
   });
 
   test("sets nowrap class to line if linesWrapping undefined", () => {

--- a/src/code-view/highlight/index.tsx
+++ b/src/code-view/highlight/index.tsx
@@ -25,7 +25,7 @@ export function createHighlight(rules: Ace.HighlightRules): CreateHighlightType 
                 token.value
               );
             })}
-            {"\n"}
+            {lineIndex < tokens.length - 1 ? "\n" : ""}
           </Fragment>
         ))}
       </span>

--- a/src/code-view/internal.tsx
+++ b/src/code-view/internal.tsx
@@ -28,7 +28,7 @@ const textHighlight = (code: string) => {
       {lines.map((line, lineIndex) => (
         <span key={lineIndex}>
           {line}
-          {"\n"}
+          {lineIndex < lines.length - 1 ? "\n" : ""}
         </span>
       ))}
     </span>


### PR DESCRIPTION
### Description

Removes a stray trailing `\n` that `CodeView` was emitting after the last rendered line in both the plain-text and syntax-highlighted render paths. Output now equals input verbatim, and user-supplied trailing newlines are preserved.

Related links, issue #, if available: n/a

### How has this been tested?

- Added unit tests asserting exact `textContent` for single-line, multi-line, trailing-newline, and highlighted inputs.
- All existing unit tests pass.
