### PR TITLE
chore: One-theme colors

### DIFF
--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -7,6 +7,8 @@
 
 $color-background-code-view-light: #f8f8f8;
 $color-background-code-view-dark: #282c34;
+$color-background-code-view-one-theme-light: #f5f5f5;
+$color-background-code-view-one-theme-dark: #3b3b3b;
 
 .root {
   position: relative;
@@ -19,6 +21,13 @@ $color-background-code-view-dark: #282c34;
   :global(.awsui-dark-mode) &,
   :global(.awsui-polaris-dark-mode) & {
     background-color: $color-background-code-view-dark;
+  }
+  :global(.awsui-one-theme) & {
+    background-color: $color-background-code-view-one-theme-light;
+  }
+  :global(.awsui-one-theme.awsui-dark-mode) &,
+  :global(.awsui-one-theme.awsui-polaris-dark-mode) & {
+    background-color: $color-background-code-view-one-theme-dark;
   }
 }
 
@@ -60,6 +69,13 @@ $color-background-code-view-dark: #282c34;
   :global(.awsui-polaris-dark-mode) & {
     background-color: $color-background-code-view-dark;
   }
+  :global(.awsui-one-theme) & {
+    background-color: $color-background-code-view-one-theme-light;
+  }
+  :global(.awsui-one-theme.awsui-dark-mode) &,
+  :global(.awsui-one-theme.awsui-polaris-dark-mode) & {
+    background-color: $color-background-code-view-one-theme-dark;
+  }
 }
 
 .unselectable {
@@ -80,6 +96,7 @@ $color-background-code-view-dark: #282c34;
 }
 
 .code-table-with-line-wrapping {
+  /* stylelint-disable-next-line no-descending-specificity */
   .line-number,
   .code-line {
     vertical-align: text-top;

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -89,7 +89,6 @@ $color-background-code-view-one-theme-dark: #3b3b3b;
 }
 
 .code-table-with-line-wrapping {
-  /* stylelint-disable-next-line no-descending-specificity */
   .line-number,
   .code-line {
     vertical-align: text-top;

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -10,13 +10,7 @@ $color-background-code-view-dark: #282c34;
 $color-background-code-view-one-theme-light: #f5f5f5;
 $color-background-code-view-one-theme-dark: #3b3b3b;
 
-.root {
-  position: relative;
-  border-start-start-radius: cs.$border-radius-tiles;
-  border-start-end-radius: cs.$border-radius-tiles;
-  border-end-start-radius: cs.$border-radius-tiles;
-  border-end-end-radius: cs.$border-radius-tiles;
-
+@mixin themed-background {
   background-color: $color-background-code-view-light;
   :global(.awsui-dark-mode) &,
   :global(.awsui-polaris-dark-mode) & {
@@ -29,6 +23,16 @@ $color-background-code-view-one-theme-dark: #3b3b3b;
   :global(.awsui-one-theme.awsui-polaris-dark-mode) & {
     background-color: $color-background-code-view-one-theme-dark;
   }
+}
+
+.root {
+  @include themed-background;
+
+  position: relative;
+  border-start-start-radius: cs.$border-radius-tiles;
+  border-start-end-radius: cs.$border-radius-tiles;
+  border-end-start-radius: cs.$border-radius-tiles;
+  border-end-end-radius: cs.$border-radius-tiles;
 }
 
 .scroll-container {
@@ -55,6 +59,8 @@ $color-background-code-view-one-theme-dark: #3b3b3b;
 }
 
 .line-number {
+  @include themed-background;
+
   white-space: nowrap;
   position: sticky;
   inset-inline-start: 0;
@@ -63,19 +69,6 @@ $color-background-code-view-one-theme-dark: #3b3b3b;
   border-inline-end-color: cs.$color-border-divider-default;
   padding-inline-start: cs.$space-static-xs;
   padding-inline-end: cs.$space-static-xs;
-
-  background-color: $color-background-code-view-light;
-  :global(.awsui-dark-mode) &,
-  :global(.awsui-polaris-dark-mode) & {
-    background-color: $color-background-code-view-dark;
-  }
-  :global(.awsui-one-theme) & {
-    background-color: $color-background-code-view-one-theme-light;
-  }
-  :global(.awsui-one-theme.awsui-dark-mode) &,
-  :global(.awsui-one-theme.awsui-polaris-dark-mode) & {
-    background-color: $color-background-code-view-one-theme-dark;
-  }
 }
 
 .unselectable {


### PR DESCRIPTION
### Description

Modified existing local design tokens for the code view background in one theme.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
