### PR TITLE
chore: Replace background with a proper token

### DIFF
--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -83,3 +83,4 @@
   inset-inline-end: cs.$space-scaled-xs;
   padding-inline-start: cs.$space-container-horizontal;
 }
+

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -5,29 +5,8 @@
 
 @use "../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
 
-$color-background-code-view-light: #f8f8f8;
-$color-background-code-view-dark: #282c34;
-$color-background-code-view-one-theme-light: #f5f5f5;
-$color-background-code-view-one-theme-dark: #3b3b3b;
-
-@mixin themed-background {
-  background-color: $color-background-code-view-light;
-  :global(.awsui-dark-mode) &,
-  :global(.awsui-polaris-dark-mode) & {
-    background-color: $color-background-code-view-dark;
-  }
-  :global(.awsui-one-theme) & {
-    background-color: $color-background-code-view-one-theme-light;
-  }
-  :global(.awsui-one-theme.awsui-dark-mode) &,
-  :global(.awsui-one-theme.awsui-polaris-dark-mode) & {
-    background-color: $color-background-code-view-one-theme-dark;
-  }
-}
-
 .root {
-  @include themed-background;
-
+  background-color: cs.$color-background-code-view;
   position: relative;
   border-start-start-radius: cs.$border-radius-tiles;
   border-start-end-radius: cs.$border-radius-tiles;
@@ -59,7 +38,7 @@ $color-background-code-view-one-theme-dark: #3b3b3b;
 }
 
 .line-number {
-  @include themed-background;
+  background-color: cs.$color-background-code-view;
 
   white-space: nowrap;
   position: sticky;

--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -83,4 +83,3 @@
   inset-inline-end: cs.$space-scaled-xs;
   padding-inline-start: cs.$space-container-horizontal;
 }
-


### PR DESCRIPTION
### Description
This PR replaces the hardcoded background color for the code view component with the proper token that we introduce in https://github.com/cloudscape-design/components/pull/4638.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
