### PR TITLE
revert: Chore: Replace background with a proper token (#145)

### DIFF
--- a/src/code-view/styles.scss
+++ b/src/code-view/styles.scss
@@ -5,8 +5,29 @@
 
 @use "../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
 
+$color-background-code-view-light: #f8f8f8;
+$color-background-code-view-dark: #282c34;
+$color-background-code-view-one-theme-light: #f5f5f5;
+$color-background-code-view-one-theme-dark: #3b3b3b;
+
+@mixin themed-background {
+  background-color: $color-background-code-view-light;
+  :global(.awsui-dark-mode) &,
+  :global(.awsui-polaris-dark-mode) & {
+    background-color: $color-background-code-view-dark;
+  }
+  :global(.awsui-one-theme) & {
+    background-color: $color-background-code-view-one-theme-light;
+  }
+  :global(.awsui-one-theme.awsui-dark-mode) &,
+  :global(.awsui-one-theme.awsui-polaris-dark-mode) & {
+    background-color: $color-background-code-view-one-theme-dark;
+  }
+}
+
 .root {
-  background-color: cs.$color-background-code-view;
+  @include themed-background;
+
   position: relative;
   border-start-start-radius: cs.$border-radius-tiles;
   border-start-end-radius: cs.$border-radius-tiles;
@@ -38,7 +59,7 @@
 }
 
 .line-number {
-  background-color: cs.$color-background-code-view;
+  @include themed-background;
 
   white-space: nowrap;
   position: sticky;


### PR DESCRIPTION
This reverts commit d4ffb7fa122fd710d6c5d33235b8410ac09dc7c3.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
