### PR TITLE
revert: "fix: Externalize react subpaths in dev-pages bundle for Rolldown (#154)"

### DIFF
--- a/vite.dev-pages.config.mjs
+++ b/vite.dev-pages.config.mjs
@@ -19,7 +19,7 @@ export default defineConfig({
     outDir: "lib/dev-pages/bundle",
     sourcemap: true,
     rollupOptions: {
-      external: [/(?:\.\.\/)+?lib\/components/, /^@cloudscape-design\/(?!build-tools)/, /^react(-dom)?(\/|$)/],
+      external: [/(?:\.\.\/)+?lib\/components/, /^@cloudscape-design\/(?!build-tools)/, "react"],
     },
   },
 });


### PR DESCRIPTION
This reverts commit a7d204f619eafe6f99b1728ab1c7235fda53dfe6.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
